### PR TITLE
Allow booking with end time equal to another booking's start time

### DIFF
--- a/lib/acts_as_bookable/booking.rb
+++ b/lib/acts_as_bookable/booking.rb
@@ -24,7 +24,7 @@ module ActsAsBookable
         query = DBUtils.time_comparison(query,'time','=',opts[:time])
       end
       if(opts[:time_start].present?)
-        query = DBUtils.time_comparison(query,'time_end', '>=', opts[:time_start])
+        query = DBUtils.time_comparison(query,'time_end', '>', opts[:time_start])
       end
       if(opts[:time_end].present?)
         query = DBUtils.time_comparison(query,'time_start', '<', opts[:time_end])


### PR DESCRIPTION
Will allow us to have half a day tutoring ending at say 12p and then half a day of teaching starting at 12p.